### PR TITLE
My Privacy DNS - All public location

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -123,6 +123,22 @@ sites:
 # --- MYPDNS-GITLAB
   - name: MyPDNS Gitlab
     url: https://mypdns.org
+    icon: https://mypdns.org/uploads/-/system/appearance/favicon/1/penguin_pirate.png
+  - name: MyPDNS (BETA testing)
+    url: http://support.mypdns.org:8080/
+    icon: http://support.mypdns.org:8080/api/logo?168-2
+  - name: MyPDNS (gitlab.com)
+    url: https://gitlab.com/my-privacy-dns/
+  - name: MyPDNS (jira.com)
+    url: https://mypdns.atlassian.net/jira/software/c/projects/MAT
+  - name: MyPDNS (bitbucket.com)
+    url: https://bitbucket.org/mypdns
+  - name: MyPDNS (framagit.org)
+    url: https://framagit.org/my-privacy-dns
+  - name: MyPDNS (youtrack.space)
+    url: https://mypdns.youtrack.cloud
+  - name: MyPDNS (jetbrains.space)
+    url: https://mypdns.jetbrains.space
 # --- MINECRAFT-SERVER
 # TODO: no checking due to https://github.com/thomasmerz/upptime/issues/95
 #  - name: MCServer_jo

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -124,7 +124,7 @@ sites:
   - name: MyPDNS Gitlab
     url: https://mypdns.org
     icon: https://mypdns.org/uploads/-/system/appearance/favicon/1/penguin_pirate.png
-  - name: MyPDNS (BETA testing)
+  - name: MyPDNS (BETA testing YouTrack. Delivered by Zendesk)
     url: http://support.mypdns.org:8080/
     icon: http://support.mypdns.org:8080/api/logo?168-2
   - name: MyPDNS (gitlab.com)

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -122,7 +122,7 @@ sites:
     icon: https://raw.githubusercontent.com/thomasmerz/upptime/master/assets/openvpn_104297.png
 # --- MYPDNS-GITLAB
   - name: MyPDNS Gitlab
-    url: https://mypdns.org
+    url: https://mypdns.org/-/liveness?token=8QTcgMMaEQgzGtdxwPui%27
     icon: https://mypdns.org/uploads/-/system/appearance/favicon/1/penguin_pirate.png
   - name: MyPDNS (BETA testing YouTrack. Delivered by Zendesk)
     url: http://support.mypdns.org:8080/


### PR DESCRIPTION
Added all public domains and path of mypdns.org issues (backups) This should be helping everyone to always being able to find and locate a working (hopefully fresh) copy of whatever lists you might use

Related: https://github.com/thomasmerz/upptime/issues/995, https://github.com/blocklistproject/Lists/issues/738#issuecomment-1162451690, https://github.com/blocklistproject/Lists/pull/678